### PR TITLE
SWITCHYARD-2743 TransactionMixIn.participate() fails if it's not yet …

### DIFF
--- a/components/test/mixins/jca/src/main/java/org/switchyard/component/test/mixins/transaction/TransactionMixIn.java
+++ b/components/test/mixins/jca/src/main/java/org/switchyard/component/test/mixins/transaction/TransactionMixIn.java
@@ -119,9 +119,13 @@ public class TransactionMixIn extends AbstractTestMixIn
 
     @Override
     public void participate(Deployment deployment) throws Exception {
+        // TODO Refactor mixins init procedure to respect participant dependency
+        // https://issues.jboss.org/browse/SWITCHYARD-2743
+        if (_jtaEnvironmentBean == null) {
+            initialize();
+        }
         deployment.getServices().add(org.jboss.weld.transaction.spi.TransactionServices.class,
             new LocalArjunaTransactionServices(_jtaEnvironmentBean));
     }
-
 
 }


### PR DESCRIPTION
…initialize()d

with a reproducer - https://github.com/igarashitm/switchyard/tree/SWITCHYARD-2743_reproducer