### PR TITLE
SWITCHYARD-2688 Switchyard endpoints do not work when used in the enr…

### DIFF
--- a/components/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/switchyard/SwitchYardProducer.java
+++ b/components/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/switchyard/SwitchYardProducer.java
@@ -78,7 +78,7 @@ public class SwitchYardProducer extends DefaultProducer {
     @Override
     public void process(final org.apache.camel.Exchange camelExchange) throws Exception {
         final String namespace = camelExchange.getProperty(CamelConstants.APPLICATION_NAMESPACE, String.class);
-        final String targetUri = camelExchange.getProperty(org.apache.camel.Exchange.TO_ENDPOINT, String.class);
+        final String targetUri = getEndpoint().getEndpointUri();
         ServiceDomain domain = ((SwitchYardCamelContext) camelExchange.getContext()).getServiceDomain();
         final ServiceReference serviceRef = lookupServiceReference(targetUri, namespace, domain, 
                 camelExchange.getProperty(SwitchYardConsumer.COMPONENT_NAME, QName.class));

--- a/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/EnrichService.java
+++ b/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/EnrichService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.camel.deploy.support;
+
+public interface EnrichService {
+
+    Integer aaa(Integer id);
+
+    Integer doNothing(Integer id);
+
+    Integer zzz(Integer id);
+}

--- a/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/EnrichServiceImpl.java
+++ b/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/EnrichServiceImpl.java
@@ -1,0 +1,23 @@
+package org.switchyard.component.camel.deploy.support;
+
+import org.switchyard.component.bean.Service;
+
+@Service(EnrichService.class)
+public class EnrichServiceImpl implements EnrichService {
+
+    @Override
+    public Integer aaa(Integer id) {
+        throw new RuntimeException("invalid execution");
+    }
+
+    @Override
+    public Integer doNothing(Integer id) {
+        return id;
+    }
+
+    @Override
+    public Integer zzz(Integer id) {
+        throw new RuntimeException("invalid execution");
+    }
+
+}

--- a/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/impl-route.xml
+++ b/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/impl-route.xml
@@ -16,6 +16,7 @@
     <route id="CamelTestRoute">
         <from uri="switchyard://OrderService"/>
         <log message="ItemId [${body}]"/>
+        <enrich uri="switchyard://EnrichService?operationName=doNothing"/>
         <to uri="switchyard://WarehouseService?operationName=hasItem"/>
         <log message="Title Name [${body}]"/>
         <log message="Properties [{{user.name}}, {{prop.domain}}, {{prop.composite}}, {{prop.component}}]"/>

--- a/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
+++ b/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
@@ -32,10 +32,19 @@
             <sca:service name="OrderService" >
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
             </sca:service>
+            <sca:reference name="EnrichService">
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.EnrichService"/>
+            </sca:reference>
             <sca:reference name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
             <sca:property name="prop.component" value="prop.component value"/>
+        </sca:component>
+        <sca:component name="EnrichComponent">
+            <bean:implementation.bean class="org.switchyard.component.camel.deploy.support.EnrichServiceImpl"/>
+            <sca:service name="EnrichService" >
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.EnrichService"/>
+            </sca:service>
         </sca:component>
         <sca:property name="prop.composite" value="prop.composite value"/>
     </sca:composite>


### PR DESCRIPTION
…ich EIP in a camel route

The endpoint URI is still applicable when it's invoked via enrich DSL while CamelToEndpoint is not