### PR TITLE
SWITCHYARD-2795 faultTo addressing in soap-addressing quickstart does…

### DIFF
--- a/quickstarts/soap-addressing/src/main/java/org/switchyard/quickstarts/soap/addressing/ServiceTransformers.java
+++ b/quickstarts/soap-addressing/src/main/java/org/switchyard/quickstarts/soap/addressing/ServiceTransformers.java
@@ -75,17 +75,6 @@ public class ServiceTransformers {
         return toElement(ackXml.toString());
     }
 
-    @Transformer(to = "{urn:switchyard-quickstart:soap-addressing:1.0}ItemNotAvailable")
-    public Element transformFromItemNotAvailable(ItemNotAvailable fault) {
-        StringBuffer ackXml = new StringBuffer()
-            .append("<SOAP-ENV:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\">")
-            .append("<faultcode>SOAP-ENV:Server</faultcode>")
-            .append("<faultstring>" + fault.getMessage() + "</faultstring>")
-            .append("</SOAP-ENV:Fault>");
-
-        return toElement(ackXml.toString());
-    }
-
     /**
      * Returns the text value of a child node of parent.
      */


### PR DESCRIPTION
…n't work

ItemNotAvailable exception should be thrown back to the SOAP consumer to trigger faultTo addressing, but the transformer tries to transform it into SOAP payload and fail, then the unchecked exception is thrown. That causes an unexpected behavior when not available item is specified.