### PR TITLE
SWITCHYARD-2814 sendFault() shouldn't be used on InOnly

### DIFF
--- a/components/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/switchyard/SwitchYardConsumer.java
+++ b/components/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/switchyard/SwitchYardConsumer.java
@@ -108,12 +108,17 @@ public class SwitchYardConsumer extends DefaultConsumer implements ServiceHandle
                 }
             }
 
+            // SWITCHYARD-2814 - since fault type is never declared on IN_ONLY operation,
+            // any Throwable will be wrapped with HandlerException. Even if the Java interface
+            // declares any Exception on service operation, that will be ignored.
             if (camelFault != null && declaredFault != null && declaredFault.isAssignableFrom(camelFault.getClass())) {
                 Message msg = switchyardExchange.createMessage().setContent(camelFault);
                 switchyardExchange.sendFault(msg);
             } else if (camelFault instanceof Throwable) {
                 throw new HandlerException(Throwable.class.cast(camelFault));
             } else if (camelFault instanceof Node) {
+                // TODO SWITCHYARD-2816 - Check if the fault is declared in WSDL, otherwise
+                // wrap the fault with HandlerException
                 Message msg = switchyardExchange.createMessage().setContent((Node)camelFault);
                 switchyardExchange.sendFault(msg);
             } else {

--- a/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/OrderServiceWithFaultInOnly.java
+++ b/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/OrderServiceWithFaultInOnly.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.camel.deploy.support;
+
+/**
+ * Simple interface intended for testing.
+ * 
+ * @author Daniel Bevenius
+ */
+public interface OrderServiceWithFaultInOnly {
+
+    void getTitleForItem(String itemId) throws CustomException;
+
+}

--- a/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/UndeclaredFaultException.java
+++ b/components/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/UndeclaredFaultException.java
@@ -1,0 +1,9 @@
+package org.switchyard.component.camel.deploy.support;
+
+public class UndeclaredFaultException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public UndeclaredFaultException(String message) {
+        super(message);
+    }
+}

--- a/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/error-route-inonly.xml
+++ b/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/error-route-inonly.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<routes xmlns="http://camel.apache.org/schema/spring">
+    <route id="CamelTestRouteInOnly">
+        <from uri="switchyard://OrderServiceInOnly" />
+        <log message="ItemId [${body}]"/>
+        <to uri="mock://throw"/>
+        <log message="Title Name [${body}]"/>
+    </route>
+</routes>

--- a/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-declared-fault.xml
+++ b/components/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-declared-fault.xml
@@ -25,6 +25,14 @@
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderServiceWithFault"/>
             </sca:service>
         </sca:component>
+        <sca:component name="CamelComponentInOnly">
+            <camel:implementation.camel xmlns="urn:switchyard-component-camel:config:1.0">
+                <xml path="org/switchyard/component/camel/deploy/error-route-inonly.xml"/>
+            </camel:implementation.camel>
+            <sca:service name="OrderServiceInOnly" >
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderServiceWithFaultInOnly"/>
+            </sca:service>
+        </sca:component>
     </sca:composite>
 
 </switchyard>


### PR DESCRIPTION
No code change. the faultType is always null for IN_ONLY operation, therefore any Throwable is wrapped with HandlerException on IN_ONLY. Described it in a comment in SwitchYardConsumer and added some testcases for those fault behavior.