### PR TITLE
SWITCHYARD-2818 Fixed SoapAttachmentQuickstartTest failure

### DIFF
--- a/quickstarts/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentClient.java
+++ b/quickstarts/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentClient.java
@@ -64,6 +64,13 @@ public class SoapAttachmentClient {
         ap.setDataHandler(new DataHandler(new URLDataSource(imageUrl)));
         ap.setContentId("switchyard.png");
         msg.addAttachmentPart(ap);
+        msg.saveChanges();
+
+        // SWITCHYARD-2818/CXF-6665 - CXF does not set content-type properly.
+        String contentType = msg.getMimeHeaders().getHeader("Content-Type")[0];
+        contentType += "; start=\"<root.message@cxf.apache.org>\"; start-info=\"application/soap+xml\"; action=\"urn:switchyard-quickstart:soap-attachment:1.0:echoImage\"";
+        msg.getMimeHeaders().setHeader("Content-Type", contentType);
+
         return connection.call(msg, new URL(switchyard_web_service));
     }
 }

--- a/quickstarts/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentTest.java
+++ b/quickstarts/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentTest.java
@@ -44,7 +44,6 @@ public class SoapAttachmentTest {
         System.setProperty("org.switchyard.component.soap.client.port", "8081");
     }
 
-    @Ignore("SWITCHYARD-2821 : please reenable after fixing")
     @Test
     public void testSwitchYardWebService() throws Exception {
         SOAPMessage response = SoapAttachmentClient.sendMessage(SWITCHYARD_WEB_SERVICE);


### PR DESCRIPTION
According to CXF-6665/CXF-6431 this failure is caused by the missing properties in the Conteyt-Type MIME header. It seems that the Conteyt-Type header is overriden at somewhere in CXF client, so I needed to modify that header after SOAPMessage.saveChanges().