### PR TITLE
SWITCHYARD-2865 : Remove obsoleted DoubleCheckedLocking Checkstyle check

### DIFF
--- a/core/build/src/main/resources/checkstyle/checkstyle.xml
+++ b/core/build/src/main/resources/checkstyle/checkstyle.xml
@@ -187,7 +187,6 @@
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
         <!--<module name="AvoidInlineConditionals"/>-->
-        <module name="DoubleCheckedLocking"/>    <!-- MY FAVOURITE -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField"/>

--- a/core/runtime/src/main/java/org/switchyard/handlers/TransactionHandler.java
+++ b/core/runtime/src/main/java/org/switchyard/handlers/TransactionHandler.java
@@ -371,7 +371,10 @@ public class TransactionHandler implements ExchangeHandler {
         Transaction currentTx = null;
         try {
             currentTx = getCurrentTransaction();
-        } catch (Exception e) { e.getMessage(); } // ignore
+        } catch (Exception e) {
+            e.getMessage();
+        } // ignore
+
         if (currentTx == null) {
             buf.append("N/A");
         } else {


### PR DESCRIPTION
Remove obsoleted DoubleCheckedLocking Checkstyle check.    Also fixed a minor checkstyle issue.

https://issues.jboss.org/browse/SWITCHYARD-2865