### PR TITLE
SWITCHYARD-2891 Align console dependencies to EAP6.4

### DIFF
--- a/console/app/pom.xml
+++ b/console/app/pom.xml
@@ -17,27 +17,32 @@
     <parent>
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-console-build</artifactId>
-        <version>2.2.8.Final</version>
+        <version>2.5.11.Final</version>
+        <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.switchyard.console</groupId>
     <artifactId>switchyard-console-application</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>${parent.version}</version>
     <packaging>war</packaging>
     <name>SwitchYard: Management Console Application</name>
     <description>Integrated AS7 console application, which includes the SwitchYard extension.</description>
+    <properties>
+        <enforcer.skip>true</enforcer.skip>
+        <version.switchyard>2.1.0-SNAPSHOT</version.switchyard>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.switchyard.console</groupId>
             <artifactId>switchyard-console-extension</artifactId>
-            <version>${project.version}</version>
+            <version>${version.switchyard}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.switchyard.console</groupId>
             <artifactId>switchyard-console-extension</artifactId>
-            <version>${project.version}</version>
             <classifier>sources</classifier>
+            <version>${version.switchyard}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/console/gwt/pom.xml
+++ b/console/gwt/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>widgets</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.gwt.circuit</groupId>
+            <artifactId>circuit-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
@@ -56,6 +60,10 @@
         <dependency>
             <groupId>com.gwtplatform</groupId>
             <artifactId>gwtp-mvp-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.gwtplatform</groupId>
+            <artifactId>gwtp-mvp-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gwt-log</groupId>

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/application/ApplicationPresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/application/ApplicationPresenter.java
@@ -42,9 +42,9 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.TabInfo;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
 import com.gwtplatform.mvp.client.proxy.RevealContentEvent;
 import com.gwtplatform.mvp.client.proxy.TabContentProxyPlace;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ApplicationPresenter

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/artifacts/ArtifactPresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/artifacts/ArtifactPresenter.java
@@ -39,9 +39,9 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.TabInfo;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
 import com.gwtplatform.mvp.client.proxy.RevealContentEvent;
 import com.gwtplatform.mvp.client.proxy.TabContentProxyPlace;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ArtifactPresenter

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/common/GWTPTabPanel.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/common/GWTPTabPanel.java
@@ -29,7 +29,7 @@ import com.gwtplatform.mvp.client.Tab;
 import com.gwtplatform.mvp.client.TabData;
 import com.gwtplatform.mvp.client.TabPanel;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * GWTPTabPanel

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/config/ConfigPresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/config/ConfigPresenter.java
@@ -41,10 +41,10 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.proxy.Place;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest.Builder;
 import com.gwtplatform.mvp.client.proxy.Proxy;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest.Builder;
 
 /**
  * ConfigPresenter

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/reference/ReferenceEditor.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/reference/ReferenceEditor.java
@@ -29,7 +29,7 @@ import org.switchyard.console.client.ui.widgets.NamespaceFormItem;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ReferenceEditor

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/reference/ReferencePresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/reference/ReferencePresenter.java
@@ -39,10 +39,10 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.TabInfo;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
 import com.gwtplatform.mvp.client.proxy.ResetPresentersEvent;
 import com.gwtplatform.mvp.client.proxy.RevealContentEvent;
 import com.gwtplatform.mvp.client.proxy.TabContentProxyPlace;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ReferencePresenter

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/runtime/RuntimePresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/runtime/RuntimePresenter.java
@@ -15,7 +15,6 @@
 package org.switchyard.console.client.ui.runtime;
 
 import org.jboss.as.console.client.plugins.RuntimeGroup;
-import org.jboss.as.console.client.shared.state.ServerSelectionChanged;
 import org.jboss.as.console.client.shared.subsys.RevealStrategy;
 import org.jboss.as.console.spi.AccessControl;
 import org.jboss.as.console.spi.RuntimeExtension;
@@ -43,8 +42,7 @@ import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
  * 
  * @author Rob Cernich
  */
-public class RuntimePresenter extends TabContainerPresenter<RuntimePresenter.MyView, RuntimePresenter.MyProxy>
-        implements ServerSelectionChanged.ChangeListener {
+public class RuntimePresenter extends TabContainerPresenter<RuntimePresenter.MyView, RuntimePresenter.MyProxy> {
 
     /**
      * MyProxy
@@ -106,11 +104,6 @@ public class RuntimePresenter extends TabContainerPresenter<RuntimePresenter.MyV
         super(eventBus, view, proxy, TYPE_SET_TAB_CONTENT, TYPE_REQUEST_TABS);
 
         _revealStrategy = revealStrategy;
-    }
-
-    @Override
-    public void onServerSelectionChanged(boolean isRunning) {
-        // getView().refreshTabs();
     }
 
     @Override

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/service/ServiceEditor.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/service/ServiceEditor.java
@@ -41,7 +41,7 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.ui.TabPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ServiceEditor

--- a/console/gwt/src/main/java/org/switchyard/console/client/ui/service/ServicePresenter.java
+++ b/console/gwt/src/main/java/org/switchyard/console/client/ui/service/ServicePresenter.java
@@ -40,10 +40,10 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.TabInfo;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.PlaceRequest;
 import com.gwtplatform.mvp.client.proxy.ResetPresentersEvent;
 import com.gwtplatform.mvp.client.proxy.RevealContentEvent;
 import com.gwtplatform.mvp.client.proxy.TabContentProxyPlace;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * ServicePresenter

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -31,8 +31,8 @@
         <url>http://github.com/jboss-switchyard/console</url>
     </scm>
     <properties>
-        <version.com.google.gwt>2.5.1</version.com.google.gwt>
-        <version.jbossas.console>2.2.8.Final</version.jbossas.console>
+        <version.com.google.gwt>2.6.1</version.com.google.gwt>
+        <version.com.gwtplatform>1.2.1</version.com.gwtplatform>
     </properties>
     <modules>
         <module>component</module>
@@ -42,17 +42,16 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jboss.as</groupId>
-                <artifactId>jboss-as-console-bom</artifactId>
-                <version>${version.jbossas.console}</version>
-                <type>pom</type>
-                <scope>import</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bsc.maven</groupId>
-                        <artifactId>maven-processor-plugin</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>com.gwtplatform</groupId>
+                <artifactId>gwtp-mvp-shared</artifactId>
+                <version>${version.com.gwtplatform}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
+                <version>${version.com.google.gwt}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -79,7 +78,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.7</version>
+                                    <version>[1.7,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <!-- Required by HAL build (app module) -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
           resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.jboss.as.console>1.5.4.Final</version.org.jboss.as.console>
+        <version.org.jboss.as.console>2.5.11.Final</version.org.jboss.as.console>
         <version.redhat.eap6.bom>6.4.4.GA</version.redhat.eap6.bom>
         <version.ip.bom>6.0.1.Final</version.ip.bom>
         <!-- This version is only used as a prefix for a jar included in release modules -->
@@ -696,6 +696,12 @@
                 <version>${version.org.jboss.as.console}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bsc.maven</groupId>
+                        <artifactId>maven-processor-plugin</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!--  ###################################################################
       ##           Dependencies Not Present in Integration BOM         ##
@@ -943,7 +949,7 @@
             <dependency>
                 <groupId>org.switchyard.console</groupId>
                 <artifactId>switchyard-console-application</artifactId>
-                <version>${project.version}</version>
+                <version>${version.org.jboss.as.console}</version>
                 <classifier>resources</classifier>
             </dependency>
             <dependency>


### PR DESCRIPTION
Also relaxed enforcer rule to be able to compile with java8. Still getting ClassFormatException from drools when running karaf distribution tests though (cf. https://issues.jboss.org/browse/SWITCHYARD-2792).

In order to update dependent jboss-as-console version, I had to align the version of SwitchYard console application to jboss-as-console instead of inheriting SwitchYard version like before.