### PR TITLE
SWITCHYARD-2881 Add support for Bearer token in AuthorizationHeaderCr…

### DIFF
--- a/core/security/base/src/main/java/org/switchyard/security/credential/AuthorizationTokenCredential.java
+++ b/core/security/base/src/main/java/org/switchyard/security/credential/AuthorizationTokenCredential.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.security.credential;
+
+/**
+ * A generic TokenCredential.
+ */
+public class AuthorizationTokenCredential implements Credential {
+    
+    private static final long serialVersionUID = 1219786062529417514L;
+    private final String _scheme;
+    private final String _token;
+    
+    /**
+     * Constructor.
+     * @param scheme scheme name
+     * @param token token
+     */
+    public AuthorizationTokenCredential(String scheme, String token) {
+        _scheme = scheme;
+        _token = token;
+    }
+    
+    /**
+     * Gets scheme name.
+     * @return scheme name
+     */
+    public String getSchema() {
+        return _scheme;
+    }
+    
+    /**
+     * Gets token.
+     * @return token
+     */
+    public String getToken() {
+        return _token;
+    }
+}

--- a/core/security/base/src/test/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests.java
+++ b/core/security/base/src/test/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests.java
@@ -15,10 +15,10 @@ package org.switchyard.security.credential.extractor;
 
 import java.util.Set;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.common.io.pull.StringPuller;
+import org.switchyard.security.credential.AuthorizationTokenCredential;
 import org.switchyard.security.credential.Credential;
 import org.switchyard.security.credential.NameCredential;
 import org.switchyard.security.credential.PasswordCredential;
@@ -33,6 +33,7 @@ public class AuthorizationHeaderCredentialExtractorTests {
     private static final String BASE_PATH = "/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-";
     private static final String BASIC_TXT = BASE_PATH + "Basic.txt";
     private static final String DIGEST_TXT = BASE_PATH + "Digest.txt";
+    private static final String BEARER_TXT = BASE_PATH + "Bearer.txt";
 
     @Test
     public void testBasic() throws Exception {
@@ -80,4 +81,15 @@ public class AuthorizationHeaderCredentialExtractorTests {
         // TODO: complete per SWITCHYARD-1082
     }
 
+    @Test
+    public void testBearer() throws Exception {
+        String source = new StringPuller().pull(BEARER_TXT, AuthorizationHeaderCredentialExtractorTests.class);
+        Set<Credential> creds = new AuthorizationHeaderCredentialExtractor().extract(source);
+        Assert.assertEquals(1, creds.size());
+        Credential credential = creds.iterator().next();
+        Assert.assertEquals(AuthorizationTokenCredential.class, credential.getClass());
+        AuthorizationTokenCredential authzTokenCredential = (AuthorizationTokenCredential)credential;
+        Assert.assertEquals("Bearer", authzTokenCredential.getSchema());
+        Assert.assertEquals("mytoken-0123456789", authzTokenCredential.getToken());
+    }
 }

--- a/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Bearer.txt
+++ b/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Bearer.txt
@@ -1,0 +1,1 @@
+Bearer mytoken-0123456789


### PR DESCRIPTION
…edentialExtractor

Now it assumes arbitrary schema other than Basic and Digest as a token and store it as a generic AuthorizationTokenCredential