### PR TITLE
ENTESB-5208 bpel: wait timer longer than 30 seconds causes process to wait indefinitely

### DIFF
--- a/components/bpel/src/main/resources/bpel.properties
+++ b/components/bpel/src/main/resources/bpel.properties
@@ -66,3 +66,6 @@ bpel.riftsaw.node.name=riftsaw-scheduler-node
 
 #Configure the cache name from the infinispan module for the ProcessConf cache 
 bpel.cache-name=cluster
+
+# Set a larger interval so that jobs get assigned by default to the immediate queue
+ode.scheduler.immediateInterval=599999


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5208