### PR TITLE
SWITCHYARD-2912 camel-service quickstart failing on karaf

### DIFF
--- a/quickstarts/camel-service/pom.xml
+++ b/quickstarts/camel-service/pom.xml
@@ -50,7 +50,11 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
         <switchyard.osgi.import>*</switchyard.osgi.import>
-        <switchyard.osgi.require.capability/>
+        <switchyard.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
         <switchyard.osgi.dynamic>
             org.switchyard,org.switchyard.*
         </switchyard.osgi.dynamic>

--- a/release/karaf/features/src/main/resources/features.xml
+++ b/release/karaf/features/src/main/resources/features.xml
@@ -490,6 +490,7 @@
     </feature>
 
     <feature name="switchyard-quickstart-camel-service" version="${project.version}" resolver="(obr)">
+        <feature version="${project.version}">switchyard-bean</feature>
         <feature version="${project.version}">switchyard-camel</feature>
         <feature version="${version.org.apache.camel.features}">camel-script</feature>
         <feature version="${version.org.apache.camel.features}">camel-script-javascript</feature>

--- a/release/karaf/tests/src/test/java/org/switchyard/karaf/test/quickstarts/CamelServiceQuickstartProbe.java
+++ b/release/karaf/tests/src/test/java/org/switchyard/karaf/test/quickstarts/CamelServiceQuickstartProbe.java
@@ -1,0 +1,30 @@
+package org.switchyard.karaf.test.quickstarts;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.switchyard.remote.RemoteInvoker;
+import org.switchyard.remote.RemoteMessage;
+import org.switchyard.remote.http.HttpInvoker;
+
+public class CamelServiceQuickstartProbe extends DeploymentProbe {
+
+    private static final QName SERVICE = new QName( "urn:switchyard-quickstart:camel-service:0.1.0", "JavaDSL");
+    
+    public CamelServiceQuickstartProbe() {
+    }
+    
+    @Test
+    public void testFeatures() throws Exception {
+        // Create a new remote client invoker
+        String port = System.getProperty("org.switchyard.component.sca.client.port", "8181");
+        RemoteInvoker invoker = new HttpInvoker("http://localhost:" + port + "/switchyard-remote");
+
+        // Create the request message
+        RemoteMessage message = new RemoteMessage();
+        message.setService(SERVICE).setOperation("acceptMessage").setContent("test");
+
+        // Invoke the service
+        invoker.invoke(message);
+    }
+}

--- a/release/karaf/tests/src/test/java/org/switchyard/karaf/test/quickstarts/CamelServiceQuickstartTest.java
+++ b/release/karaf/tests/src/test/java/org/switchyard/karaf/test/quickstarts/CamelServiceQuickstartTest.java
@@ -1,0 +1,19 @@
+package org.switchyard.karaf.test.quickstarts;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CamelServiceQuickstartTest extends AbstractQuickstartTest {
+    private static String bundleName = "org.switchyard.quickstarts.switchyard.camel.service";
+    private static String featureName = "switchyard-quickstart-camel-service";
+
+    @BeforeClass
+    public static void before() throws Exception {
+        startTestContainer(featureName, bundleName, null, CamelServiceQuickstartProbe.class);
+    }
+    
+    @Test
+    public void testFeatures() throws Exception {
+        executeProbe("testFeatures");
+    }
+}


### PR DESCRIPTION
Added missing CDI capability to the bundle manifest