### PR TITLE
SWITCHYARD-2953 SwitchYard HTTP Basic Auth is case-sensitive, in violation of rfc2617

### DIFF
--- a/core/security/base/src/main/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractor.java
+++ b/core/security/base/src/main/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractor.java
@@ -84,9 +84,9 @@ public class AuthorizationHeaderCredentialExtractor implements CredentialExtract
     public Set<Credential> extract(String source) {
         Set<Credential> credentials = new HashSet<Credential>();
         if (source != null) {
-            if (source.startsWith("Basic ")) {
+            if (source.toUpperCase().startsWith("BASIC ")) {
                 extractBasic(source, credentials);
-            } else if (source.startsWith("Digest ")) {
+            } else if (source.toUpperCase().startsWith("DIGEST ")) {
                 extractDigest(source, credentials);
             } else {
                 // Assuming it's a authz token like Bearer, token, AWS4-HMAC-SHA256

--- a/core/security/base/src/test/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests.java
+++ b/core/security/base/src/test/java/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests.java
@@ -32,12 +32,41 @@ public class AuthorizationHeaderCredentialExtractorTests {
 
     private static final String BASE_PATH = "/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-";
     private static final String BASIC_TXT = BASE_PATH + "Basic.txt";
+    private static final String BASIC2_TXT = BASE_PATH + "Basic2.txt";
+
     private static final String DIGEST_TXT = BASE_PATH + "Digest.txt";
+    private static final String DIGEST2_TXT = BASE_PATH + "Digest2.txt";
     private static final String BEARER_TXT = BASE_PATH + "Bearer.txt";
 
     @Test
     public void testBasic() throws Exception {
         String source = new StringPuller().pull(BASIC_TXT, AuthorizationHeaderCredentialExtractorTests.class);
+        Set<Credential> creds = new AuthorizationHeaderCredentialExtractor().extract(source);
+        boolean foundName = false;
+        boolean foundPassword = false;
+        for (Credential cred : creds) {
+            if (cred instanceof NameCredential) {
+                foundName = true;
+                String name = ((NameCredential)cred).getName();
+                Assert.assertEquals("Aladdin", name);
+            } else if (cred instanceof PasswordCredential) {
+                foundPassword = true;
+                String password = new String(((PasswordCredential)cred).getPassword());
+                Assert.assertEquals("open sesame", password);
+            }
+        }
+        if (!foundName) {
+            Assert.fail("name not found");
+        }
+        if (!foundPassword) {
+            Assert.fail("password not found");
+        }
+    }
+
+    // SWITCHYARD-2953
+    @Test
+    public void testBasic2() throws Exception {
+        String source = new StringPuller().pull(BASIC2_TXT, AuthorizationHeaderCredentialExtractorTests.class);
         Set<Credential> creds = new AuthorizationHeaderCredentialExtractor().extract(source);
         boolean foundName = false;
         boolean foundPassword = false;
@@ -66,6 +95,28 @@ public class AuthorizationHeaderCredentialExtractorTests {
         // https://issues.jboss.org/browse/SWITCHYARD-1082
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         String source = new StringPuller().pull(DIGEST_TXT, AuthorizationHeaderCredentialExtractorTests.class);
+        Set<Credential> creds = new AuthorizationHeaderCredentialExtractor().extract(source);
+        boolean foundName = false;
+        for (Credential cred : creds) {
+            if (cred instanceof NameCredential) {
+                foundName = true;
+                String name = ((NameCredential)cred).getName();
+                Assert.assertEquals("Mufasa", name);
+            }
+        }
+        if (!foundName) {
+            Assert.fail("name not found");
+        }
+        // TODO: complete per SWITCHYARD-1082
+    }
+
+    // SWITCHYARD-2953
+    @Test
+    public void testDigest2() throws Exception {
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        // https://issues.jboss.org/browse/SWITCHYARD-1082
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        String source = new StringPuller().pull(DIGEST2_TXT, AuthorizationHeaderCredentialExtractorTests.class);
         Set<Credential> creds = new AuthorizationHeaderCredentialExtractor().extract(source);
         boolean foundName = false;
         for (Credential cred : creds) {

--- a/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Basic2.txt
+++ b/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Basic2.txt
@@ -1,0 +1,1 @@
+BASIC QWxhZGRpbjpvcGVuIHNlc2FtZQ==

--- a/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Digest2.txt
+++ b/core/security/base/src/test/resources/org/switchyard/security/credential/extractor/AuthorizationHeaderCredentialExtractorTests-Digest2.txt
@@ -1,0 +1,9 @@
+DIGEST username="Mufasa"
+       realm="testrealm@host.com"
+       nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"
+       uri="/dir/index.html"
+       qop=auth,
+       nc=00000001
+       cnonce="0a4f113b"
+       response="6629fae49393a05397450978507c4ef1"
+       opaque="5ccc069c403ebaf9f0171e9517f40e41"


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-2953