### PR TITLE
Move error logging to outer catch block

### DIFF
--- a/components/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
+++ b/components/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
@@ -262,7 +262,6 @@ public class OutboundHandler extends BaseServiceHandler {
                     }
                 }
             } catch (Exception e) {
-                LOGGER.error(e);
                 throw e instanceof SOAPException ? (SOAPException)e : new SOAPException(e);
             }
             if (LOGGER.isTraceEnabled()) {
@@ -307,6 +306,7 @@ public class OutboundHandler extends BaseServiceHandler {
             }
 
         } catch (SOAPException se) {
+            LOGGER.error(se);
             throw SOAPMessages.MESSAGES.unexpectedExceptionHandlingSOAPMessage(se);
         }
     }


### PR DESCRIPTION
This is related to the already merged https://github.com/jboss-switchyard/switchyard/pull/128, but moves the error logging to the outer catch block to ensure we are not missing to log any exceptions. Sorry for yet another PR on this issue...