### PR TITLE
Fix use of soap:endpointAddress with recent CXF version

### DIFF
--- a/components/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
+++ b/components/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
@@ -260,6 +260,13 @@ public class OutboundHandler extends BaseServiceHandler {
                     if (toAddress != null) {
                         _dispatcher.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, toAddress);
                     }
+                } else {
+                    // Defaulting to use soapAction property in request header
+                    _dispatcher.getRequestContext().put(BindingProvider.SOAPACTION_USE_PROPERTY, Boolean.TRUE);
+                }
+
+                if (_config.getEndpointAddress() != null) {
+                    _dispatcher.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, _config.getEndpointAddress());
                 }
             } catch (Exception e) {
                 throw e instanceof SOAPException ? (SOAPException)e : new SOAPException(e);


### PR DESCRIPTION
With recent (v3.1.12 vs v3.1.4) version of CXF, the RequestContext should
be updated within handleMessage rather than within doStart.
This fixes overriding the service port address in the WSDL.